### PR TITLE
Add Health and Wealth mod

### DIFF
--- a/challengedata.lua
+++ b/challengedata.lua
@@ -50,6 +50,16 @@ ChallengeMod.ChallengeData =
         SetupFunction = "PomOneBoonSetup",
         HellMode=False,
         RestoreRoomData=true,
+    },
+
+    HealthAndWealth = 
+    {
+        Name = "Eat The Rich",
+        Description = "Pick a boon in chamber one, then get health or wealth every chamber after that.",
+        Author = "colorsdontgo",
+        SetupFunction = "HealthAndWealthSetup",
+        HellMode = false,
+        RestoreRoomData = true,
     }
 
     -- BossRush =

--- a/challengescripts.lua
+++ b/challengescripts.lua
@@ -32,6 +32,25 @@ function PomOneBoonSetup()
     end
 end
 
+-- Force all rooms to be either health or wealth, and all chaos boons to be health or increased money
+function HealthAndWealthSetup()
+    for _, roomData in pairs(RoomData) do
+        if roomData.Name == "RoomOpening" then
+            roomData.SecretSpawnChance = 1.0
+            roomData.EligibleRewards = {"Boon"} -- you can have a boon, i guess.
+        elseif not string.find(roomData.Name, "Secret") then
+            roomData.EligibleRewards = {"RoomRewardMaxHealthDrop", "RoomRewardMoneyDrop"}
+            roomData.ForcedRewardStore = "RunProgress"
+        end
+    end
+
+    for _, lootData in pairs(LootData) do 
+        if lootData.Name == "TrialUpgrade" then
+            lootData.PermanentTraits = {"ChaosBlessingMaxHealthTrait", "ChaosBlessingMoneyTrait","ChaosBlessingMaxHealthTrait","ChaosBlessingMoneyTrait"} -- we need at least 3 options or the game crashes. let's try 2 of each.
+        end
+    end
+end
+
 ModUtil.Path.Wrap("IsRoomRewardEligible", function( baseFunc, run, room, reward, previouslyChosenRewards, args)
     if ChallengeMod.ActiveChallenge == ChallengeMod.ChallengeData.PomOneBoon.Name then
         local reward2 = DeepCopyTable(reward)
@@ -41,6 +60,7 @@ ModUtil.Path.Wrap("IsRoomRewardEligible", function( baseFunc, run, room, reward,
         return baseFunc(run, room, reward, previouslyChosenRewards, args)
     end
 end, ChallengeMod)
+
 function ChallengeMod.BossRushRoomset()
     for _, roomData in pairs(RoomData) do
         roomData.SecretSpawnChance = 0.0


### PR DESCRIPTION
Makes all chambers barring the first and Chaos give MaxHealth or Obals. Chaos only gives MaxHealth or obal rewards.