### PR TITLE
Fix typos in descriptions

### DIFF
--- a/challengedata.lua
+++ b/challengedata.lua
@@ -54,7 +54,7 @@ ChallengeMod.ChallengeData =
 
     HealthAndWealth = 
     {
-        Name = "Eat The Rich",
+        Name = "Health and Wealth",
         Description = "Pick a boon in chamber one, then get health or wealth every chamber after that.",
         Author = "colorsdontgo",
         SetupFunction = "HealthAndWealthSetup",
@@ -64,7 +64,7 @@ ChallengeMod.ChallengeData =
     RampUpTheSpeed = 
     {
         Name = "Ramp Up the Speed",
-        Description = "Every room, enemy speed increases by 1%",
+        Description = "Every room, enemy speed increases by 2%.",
         Author = "colorsdontgo",
         SetupFunction = "SpeedyBoisSetup",
         HellMode = false,
@@ -73,7 +73,7 @@ ChallengeMod.ChallengeData =
     EatTheRich = 
     {
         Name = "Eat The Rich",
-        Description = "At the end of every biome, lose max health based on how much money you have. ",
+        Description = "At the end of every biome, lose max health based on how much money you have. Reduces damage done to enemies by 5% of current money.",
         Author = "colorsdontgo",
         SetupFunction = "EatTheRichSetup",
         HellMode=False,

--- a/readme.md
+++ b/readme.md
@@ -15,3 +15,6 @@ To use this mod, set your keepsake/mirror/pact of punishment as desired, then wa
 - Skip Tartarus
 - Only Boons
 - Pom One Boon
+- Health and Wealth
+- Ramp Up the Speed
+- Eat the Rich


### PR DESCRIPTION
Change the descriptions to match the actual actions of the mods. Also update the name of Health and Wealth to the correct value.